### PR TITLE
Add option for page size from Graph API

### DIFF
--- a/src/main/resources/idprovider/idprovider.xml
+++ b/src/main/resources/idprovider/idprovider.xml
@@ -56,7 +56,7 @@
 
     <input name="pageSize" type="Long">
       <label>The page return size from graph api</label>
-      <default>5</default>
+      <default>1</default>
       <help-text>If the result contains more than the page size, graph api will return an @odata.nextLink property similar to the following along with the first page of users.</help-text>
       <occurrences minimum="0" maximum="1"/>
     </input>

--- a/src/main/resources/idprovider/idprovider.xml
+++ b/src/main/resources/idprovider/idprovider.xml
@@ -54,6 +54,13 @@
       <occurrences minimum="0" maximum="1"/>
     </input>
 
+    <input name="pageSize" type="Long">
+      <label>The page return size from graph api</label>
+      <default>5</default>
+      <help-text>If the result contains more than the page size, graph api will return an @odata.nextLink property similar to the following along with the first page of users.</help-text>
+      <occurrences minimum="0" maximum="1"/>
+    </input>
+
     <item-set name="groupFilter">
       <label>Group Filter</label>
       <occurrences minimum="0" maximum="0"/>

--- a/src/main/resources/lib/azure-ad-id-provider/auth/group.js
+++ b/src/main/resources/lib/azure-ad-id-provider/auth/group.js
@@ -146,15 +146,19 @@ function fromGraph(params) {
     var idProviderConfig = getIdProviderConfig();
     // https://docs.microsoft.com/en-us/graph/api/user-list-memberof?view=graph-rest-1.0&tabs=cs
     // https://developer.microsoft.com/en-us/graph/graph-explorer?request=me/memberOf&method=GET&version=v1.0&GraphUrl=https://graph.microsoft.com
+
+    var pageSize = idProviderConfig.pageSize ? '?$top=' + idProviderConfig.pageSize : '';
+
     var groupRequest = {
         method: 'GET',
-        url: 'https://graph.microsoft.com/v1.0/users/' + params.jwt.payload.oid + '/memberOf?$top=' + idProviderConfig.pageSize,
+        url: 'https://graph.microsoft.com/v1.0/users/' + params.jwt.payload.oid + '/memberOf' + pageSize,
         headers: {
             Accept: 'application/json',
             Authorization: 'Bearer ' + params.accessToken
         },
         proxy: idProviderConfig.proxy
     };
+
     log.debug('createAndUpdateGroupsOnLoginFromGraphApi request: ' + toStr(groupRequest));
 
     var groupResponse = sendRequest(groupRequest);

--- a/src/main/resources/lib/azure-ad-id-provider/auth/group.js
+++ b/src/main/resources/lib/azure-ad-id-provider/auth/group.js
@@ -148,7 +148,7 @@ function fromGraph(params) {
     // https://developer.microsoft.com/en-us/graph/graph-explorer?request=me/memberOf&method=GET&version=v1.0&GraphUrl=https://graph.microsoft.com
     var groupRequest = {
         method: 'GET',
-        url: 'https://graph.microsoft.com/v1.0/users/' + params.jwt.payload.oid + '/memberOf',
+        url: 'https://graph.microsoft.com/v1.0/users/' + params.jwt.payload.oid + '/memberOf?$top=' + idProviderConfig.pageSize,
         headers: {
             Accept: 'application/json',
             Authorization: 'Bearer ' + params.accessToken
@@ -173,7 +173,7 @@ function fromGraph(params) {
 
         // create or modify groups and add the user to the group
         var groups = body.value;
-        
+
         // filter groups
         if(idProviderConfig.groupFilter) {
             var groupFilters = forceArray(idProviderConfig.groupFilter);


### PR DESCRIPTION
The reason for this pull request: Some queries against Microsoft Graph return multiple pages of data either due to server-side paging or due to the use of the $top query parameter to specifically limit the page size in a request. When more than one query request is required to retrieve all the results, Microsoft Graph returns an @odata.nextLink property in the response that contains a URL to the next page of results. Upping the page size might be relevant when the user is part of numerous user groups.